### PR TITLE
Removed the Context struct and altered syntax to be simpler. Updated …

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ virtual void IResource<data>::exit(std::optional<std::exception> e) = 0;
 ```
 The user should create a derived class from this interface that specifies the logic they need for their usecase. 
 
-The resources will be collected into a struct called `IData`. This struct is undefined in the header so that the user can define it however they wish. Ultimately, a pointer to this struct will be made accessible to the context. *Therefore, the users rrsource manager class must be derived from* `public IResource<IData>`.
+The resources will be collected into a struct called `IData`. This struct is undefined in the header so that the user can define it however they wish. Ultimately, a pointer to this struct will be made accessible to the context. *Therefore, the users resource manager class must be derived from* `public IResource<IData>`.
 
 Initialization `IResource` supports refernce and pointer passing to give some flexibility to the user. These methods can be overridden to provide extra logic.
 ```c++
@@ -43,12 +43,10 @@ IResource<data>(data& resources) : resources(&resources){};
 IResource<data>(data* resources) : resources(resources){};
 ```
 
-Contexts are very simple in contextual. They are simply a struct that holds a function with the signature: 
+Contexts are very simple in contextual. They are simply lambda functions passed given to the resource manager that forwards it on to the context manager. This lambda function must satisfy the type: 
 ```c++ 
 std::function<void(IData*)> code_block;
 ```
-This should be passed in as a lambda function with the correct signature.
-
 The following gives an example of the usage
 ```c++
 using namespace Contextual;
@@ -68,18 +66,18 @@ int main(){
     IData resource = ...;
 
     With OptionalName {
-        Resource(resource) + Context {
+        Resource(resource)(
             [&](IData* data) {
                 ...
             }
-        }
+        )
     };
 }
 ```
 
-In the above, the `With` block can be a given a name (the `OptionalName` above), but this is not necessary. Also, a name cannot be repeated in the same scope (anonymous scoping can resolve this). Furthermore, the outermost `With` block is optional; it is merely there for syntatic clarity.
+In the above, the `With` block can be a given a name (the `OptionalName` above), but this is not necessary. Also, a name cannot be repeated in the same scope (anonymous scoping can resolve this). However, naming the `With` block is discouraged as it leaves this instance in memory until it leaves scope, unlike unnamed blocks, which are destroyed immediately (again this is fixable with anonymous scoping).
 
-In the lambda function, the `data` parameter is a pointer to the resource struct created by the Resource class via initialization / enter methods. At the end of the block, the exit method of `Resource` is called. Then the `Resource`, `Context`, and `With` objects all leave scope and have their destructors called.
+In the lambda function, the `data` parameter is a pointer to the resource struct created by the Resource class via initialization / enter methods. At the end of the block, the exit method of `Resource` is called. Then the `Resource`, and `With` objects all leave scope and have their destructors called.
 
 For more examples, see the **example.cpp** file in the top-level directory. It can be compiled by running `$ make example`. The tests in  **tests/test\_contextual\_basic.h** provide some further examples.
 
@@ -87,7 +85,7 @@ For more examples, see the **example.cpp** file in the top-level directory. It c
 
 At the moment, there are a few ways to use this library that will have negative consequences (other than obvious abuses like overriding all core functionality in derived classes).
 
-The problematic usages all have in common that one of necessary destructors does not get called. Instnaces of all three classes `With`, `IResource`, and `Context` are meant to be temporary. They should not be forward declared, copied, or assigned unless a very particular use case demands it. 
+The problematic usages all have in common that one of necessary destructors does not get called. Instnaces of the classes `With` and `IResource` are meant to be temporary. They should not be forward declared, copied, or assigned unless a very particular use case demands it. 
 
 Less obviously, if a `With` block is given a name, it's destructor will not be called at the end of the context. Therefore, if one wishes to use the optional name, the entire `With` block should be placed in an anonymous scope to make sure it does not continue consuming memory. 
 

--- a/example.cpp
+++ b/example.cpp
@@ -48,13 +48,13 @@ int main(){
 	
 	{
 		With PasswordHidden {
-			Resource(first_user) + Context {
+			Resource(first_user)(
 				eval {
 					std::cout << "Username: " << resource->username << "\n";
 					std::cout << "Password: " << resource->password << "\n";
 					resource->logged_in = true;
 				}
-			}
+			)
 		};
 	}
 	
@@ -68,32 +68,17 @@ int main(){
 
 	std::cout << "\n====================================\n\n";
 
-	With {
-		Resource("admin", "password123") + Context {
+	with {
+		Resource("admin", "password123")(
 			eval {
 				std::cout << "Username: " << resource->username << "\n";
 				std::cout << "Password: " << resource->password << "\n";
 				resource->logged_in = true;
 			}
-		}
+		)
 	};
 
 	std::cout << "Username: " << first_user.username << "\n";
 	std::cout << "Password: " << first_user.password << "\n";
-
-	std::cout << "\n====================================\n\n";
-
-	Resource(first_user) + Context {
-		eval {
-			std::cout << "Username: " << resource->username << "\n";
-			std::cout << "Password: " << resource->password << "\n";
-			resource->logged_in = true;
-		}
-	};
-	
-	
-	std::cout << "Username: " << first_user.username << "\n";
-	std::cout << "Password: " << first_user.password << "\n";
-	
 
 }


### PR DESCRIPTION
…tests and examples and documentation

Changes:
 * The Context struct has been removed
 * IResource forwards  the code block to the With class ( done by overloading the () operator)
 * Using a With block is now mandatory 

